### PR TITLE
Allow environment setting with string

### DIFF
--- a/lib/affirm/configuration.rb
+++ b/lib/affirm/configuration.rb
@@ -2,7 +2,7 @@ module Affirm
   class Configuration
     attr_accessor :public_api_key
     attr_accessor :private_api_key
-    attr_accessor :environment
+    attr_reader :environment
 
     ENDPOINTS = {
       production: "api.affirm.com",
@@ -11,6 +11,10 @@ module Affirm
 
     def initialize
       @environment = :production
+    end
+
+    def environment=(env)
+      @environment = env.to_sym
     end
 
     def endpoint

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -54,18 +54,36 @@ RSpec.describe Affirm::Configuration do
   end
 
   context "when environment is set to sandbox" do
-    before do
-      Affirm.configure do |config|
-        config.environment = :sandbox
+    context "via string" do
+      before do
+        Affirm.configure do |config|
+          config.environment = 'sandbox'
+        end
+      end
+
+      it "sets environment to sandbox" do
+        expect(Affirm.configuration.environment).to eq(:sandbox)
+      end
+
+      it "sets endpoint to sandbox" do
+        expect(Affirm.configuration.endpoint).to eq("https://sandbox.affirm.com")
       end
     end
 
-    it "sets environment to sandbox" do
-      expect(Affirm.configuration.environment).to eq(:sandbox)
-    end
+    context "via symbol" do
+      before do
+        Affirm.configure do |config|
+          config.environment = :sandbox
+        end
+      end
 
-    it "sets endpoint to sandbox" do
-      expect(Affirm.configuration.endpoint).to eq("https://sandbox.affirm.com")
+      it "sets environment to sandbox" do
+        expect(Affirm.configuration.environment).to eq(:sandbox)
+      end
+
+      it "sets endpoint to sandbox" do
+        expect(Affirm.configuration.endpoint).to eq("https://sandbox.affirm.com")
+      end
     end
   end
 


### PR DESCRIPTION
This is sort of small and stupid. Feel free to say "no thanks" and reject this.

In my own app, I just wanted to be able to pass a string in rather than a symbol. That way I can pull the environment choice out of an ENV variable without having to convert it. 
