### PR TITLE
bump faraday and friends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in affirm.gemspec
 gemspec
-
-gem "bundler", "~> 1.7"
-gem "rake",    "~> 10.0"
-gem "rspec",   "~> 3.3.0"
-gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     affirm-ruby (1.0.2)
-      faraday (~> 0.9.1)
-      faraday_middleware (~> 0.10.0)
+      faraday
+      faraday_middleware
       virtus (~> 1.0, >= 1.0.0)
 
 GEM
@@ -22,12 +22,12 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     equalizer (0.0.11)
-    faraday (0.9.1)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    ice_nine (0.11.1)
-    multipart-post (2.0.0)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
+    ice_nine (0.11.2)
+    multipart-post (2.1.1)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -42,7 +42,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -54,10 +54,10 @@ PLATFORMS
 
 DEPENDENCIES
   affirm-ruby!
-  bundler (~> 1.7)
+  bundler
   byebug
-  rake (~> 10.0)
+  rake
   rspec (~> 3.3.0)
 
 BUNDLED WITH
-   1.10.5
+   2.0.2

--- a/affirm.gemspec
+++ b/affirm.gemspec
@@ -19,7 +19,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = "~> 2.1"
-  spec.add_dependency "faraday", "~> 0.9.1"
-  spec.add_dependency "faraday_middleware", "~> 0.10.0"
+  spec.add_dependency "faraday"
+  spec.add_dependency "faraday_middleware"
   spec.add_dependency "virtus", "~> 1.0", ">= 1.0.0"
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "~> 3.3.0"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/affirm/version.rb
+++ b/lib/affirm/version.rb
@@ -1,3 +1,3 @@
 module Affirm
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Loosen the dependency on faraday so this can be used in more recent installations without downgrading the versions.

When users still need the older versions for faraday, they can add the specific version needed in the host application. This way we don't lock in any user in using the specific faraday version

I also move Gemfile gems to the proper gemspec places and bumped the version a minor version.
