### PR TITLE
Upgrade to Faraday 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    affirm-ruby (1.1.1)
+    affirm-ruby (1.2.0)
       faraday
-      faraday_middleware
       virtus (~> 1.0, >= 1.0.0)
 
 GEM
@@ -13,35 +12,35 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    byebug (5.0.0)
-      columnize (= 0.9.0)
+    base64 (0.1.1)
+    byebug (11.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    columnize (0.9.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     equalizer (0.0.11)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
+    faraday (2.7.11)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
     ice_nine (0.11.2)
-    multipart-post (2.1.1)
-    rake (13.0.1)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rake (13.1.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    ruby2_keywords (0.0.5)
     thread_safe (0.3.6)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -50,7 +49,7 @@ GEM
       equalizer (~> 0.0, >= 0.0.9)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
 
 DEPENDENCIES
   affirm-ruby!
@@ -60,4 +59,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.0.2
+   2.4.19

--- a/affirm.gemspec
+++ b/affirm.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = [">= 2.1", "< 4.0"]
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
   spec.add_dependency "virtus", "~> 1.0", ">= 1.0.0"
 
   spec.add_development_dependency "bundler"

--- a/lib/affirm.rb
+++ b/lib/affirm.rb
@@ -1,7 +1,6 @@
 require "forwardable"
 
 require "faraday"
-require "faraday_middleware"
 require "virtus"
 
 require "affirm/client"

--- a/lib/affirm/client.rb
+++ b/lib/affirm/client.rb
@@ -14,7 +14,7 @@ module Affirm
     def initialize
       @url_prefix = "/api/v2"
       @connection = Faraday.new(Affirm.configuration.endpoint) do |conn|
-        conn.basic_auth(basic_auth_user, basic_auth_password)
+        conn.request :authorization, :basic, basic_auth_user, basic_auth_password
         conn.request  :json
         conn.response :json, content_type: /\bjson$/
         conn.adapter  Faraday.default_adapter

--- a/lib/affirm/version.rb
+++ b/lib/affirm/version.rb
@@ -1,3 +1,3 @@
 module Affirm
-  VERSION = "1.1.3"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Upgrading to use Faraday v2.x
minor change updating basic authorization
removed unnecessary faraday_middleware